### PR TITLE
[doc] CAPI should be in reference, fixes #6.

### DIFF
--- a/docs/developer-guide/reference.md
+++ b/docs/developer-guide/reference.md
@@ -9,7 +9,7 @@ of each. See also the [overview of SDC repositories](./repos.md).
 ## Services
 
 By "Services" here, we mean SAPI services of type "vm". See [the *service*
-section in the glossary](./glossary.md#service) for details.
+section in the glossary](../glossary.md#service) for details.
 
 | Name | Repo | Description |
 | ---- | ---- | ----------- |
@@ -33,14 +33,14 @@ section in the glossary](./glossary.md#service) for details.
 | [redis](https://github.com/joyent/sdc-redis/blob/master/docs/index.restdown) | [sdc-redis](https://github.com/joyent/sdc-redis) | SDC internal redis |
 | [sapi](https://github.com/joyent/sdc-sapi/blob/master/docs/index.restdown) | [sdc-sapi](https://github.com/joyent/sdc-sapi) | SDC Service API |
 | [sdc](https://github.com/joyent/sdc-sdc/blob/master/docs/index.restdown) | [sdc-sdc](https://github.com/joyent/sdc-sdc) | SDC internal "sdc" zone with ops tooling |
-| [ufds](https://github.com/joyent/sdc-ufds/blob/master/docs/index.restdown) | [sdc-ufds](https://github.com/joyent/sdc-ufds) | SDC LDAP directory service (used primarily for user management) |
+| [ufds](https://github.com/joyent/sdc-ufds/blob/master/docs/index.restdown) | [sdc-ufds](https://github.com/joyent/sdc-ufds) | SDC LDAP directory service. It is used primarily for user management. The customer API (CAPI) runs in this zone. |
 | [vmapi](https://github.com/joyent/sdc-vmapi/blob/master/docs/index.restdown) | [sdc-vmapi](https://github.com/joyent/sdc-vmapi) | SDC Virtual Machine API |
 | [workflow](https://github.com/joyent/sdc-workflow/blob/master/docs/index.restdown) | [sdc-workflow](https://github.com/joyent/sdc-workflow) | SDC Workflow API and job runner service |
 
 ## Agents
 
 By "Agents" here, we mean all SDC agents as described by the [*agent* section in
-the glossary](./glossary.md#agent). The "Where" column of this table indicates
+the glossary](../glossary.md#agent). The "Where" column of this table indicates
 where an instance of this agent is typically running: "vm" means in SDC core
 VMs, "gz" means in the global zone of SDC servers (both the headnode and
 compute nodes).


### PR DESCRIPTION
- Also fixes links in Reference to Glossary.
