### PR TITLE
Fix health check typo in CoaL setup example.

### DIFF
--- a/docs/developer-guide/coal-setup.md
+++ b/docs/developer-guide/coal-setup.md
@@ -356,7 +356,7 @@ Update channel has been successfully set to: 'dev'
 It's a good idea to check the health of CoaL using `sdcadm check-health`
 before each step. Until [TOOLS-1001: "sdcadm check-health" should
 include "sdc-healthcheck" global results](https://smartos.org/bugview/TOOLS-1001)
-is resolved, you should also run `sdc-healthchek`.
+is resolved, you should also run `sdc-healthcheck`.
 
 ### Self Update
 


### PR DESCRIPTION
The third `c` in `sdc-healthcheck` is omitted, resulting in a command that doesn't exist `sdc-healthchek`. This pull request fixes the typo and results in a correctly spelled command.