### PR TITLE
Make clear that CoaL works with Fusion 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ headnode.
     ```
 
 2. Install VMware, if you haven't already.
-    - Mac: [VMware Fusion](http://www.vmware.com/products/fusion) 5 or 7.
+    - Mac: [VMware Fusion](http://www.vmware.com/products/fusion) 5, 7, or 8.
     - Windows or Linux: [VMware Workstation](http://www.vmware.com/products/workstation).
 
 3. Configure VMware virtual networks for CoaL's "external" and "admin"

--- a/docs/developer-guide/coal-setup.md
+++ b/docs/developer-guide/coal-setup.md
@@ -45,7 +45,7 @@ At a high level, setting up CoaL involves:
     curl -C - -O https://us-east.manta.joyent.com/Joyent_Dev/public/SmartDataCenter/coal-latest.tgz
 
 2. Install VMware, if you haven't already.
-    - Mac: [VMware Fusion](http://www.vmware.com/products/fusion) 5 or 7.
+    - Mac: [VMware Fusion](http://www.vmware.com/products/fusion) 5, 7, or 8.
     - Windows or Linux: [VMware Workstation](http://www.vmware.com/products/workstation).
 
 3. Configure VMware virtual networks for CoaL's "external" and "admin"

--- a/tools/coal-mac-vmware-setup
+++ b/tools/coal-mac-vmware-setup
@@ -44,7 +44,7 @@ if [[ -e "/Applications/VMware Fusion.app/Contents/Library/services.sh" ]]; then
     FUSION4=true
 fi
 
-# Detect if Fusion 7 is installed
+# Detect if Fusion 7 or Fusion 8 is installed
 if [[ -e "/Applications/VMware Fusion.app/Contents/Library/vmrun" ]]; then
     BIN_DIR="/Applications/VMware Fusion.app/Contents/Library"
     SETTINGS_DIR="/Library/Preferences/VMware Fusion"


### PR DESCRIPTION
It wasn't clear from the documentation that CoaL works with VMware Fusion 8. I tried it, and it works just like Fusion 7. So, I made the appropriate changes to the documentation.