### PR TITLE
Fixed documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ SDC consists of the following components:
 
 For more details, see:
 
-- The [Overview of SmartDataCenter 7](https://docs.joyent.com/sdc7/overview-of-smartdatacenter-7)
+- The [Overview of Triton Elastic Container Infrastructure](https://docs.joyent.com/private-cloud)
   in the Joyent customer documentation.
 - [SmartDataCenter Architecture](./docs/developer-guide/architecture.md) for
   overall architecture.
@@ -279,24 +279,10 @@ curl -C - -O https://us-east.manta.joyent.com/Joyent_Dev/public/SmartDataCenter/
 ```
 
 Once you have downloaded the latest release image, you will need to
-[write it to a USB key](https://docs.joyent.com/private-cloud/install/installation-media),
-boot the headnode server using the USB key, and follow the install prompts. See
-the the Joyent customer documentation "[installing SDC 7](https://docs.joyent.com/sdc7/installing-sdc7)"
-and "[install checklist](https://docs.joyent.com/sdc7/installing-sdc7/install-checklist)"
-for information.
-
-After installation, you will probably want to perform some
-[additional configuration](https://docs.joyent.com/sdc7/installing-sdc7/post-installation-configuration).
-The most common of these include:
-
-- [Adding external nics to the imgapi and adminui zones](https://docs.joyent.com/sdc7/installing-sdc7/post-installation-configuration#AddingExternalNICstoHeadNodeVMs)
-  to give them internet access. This enables simple import of VM images.
-- [Provision a CloudAPI zone](https://docs.joyent.com/sdc7/installing-sdc7/post-installation-configuration#CreatingCloudAPI)
-  to allow users to create and administer their VMs without an operator.
-
-See the
-[post-installation configuration documentation](https://docs.joyent.com/sdc7/installing-sdc7/post-installation-configuration)
-for the complete list.
+[write it to a USB key](https://docs.joyent.com/private-cloud/install/installation-media)
+boot the headnode server using the USB key, and follow the install prompts. All steps necessary
+to plan, install, and configure SmartDataCenter (Triton) are available in the Joyent 
+customer documenation [Installing Triton Elastic Container Infrastructure](https://docs.joyent.com/private-cloud/install).
 
 
 ## Building

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -18,7 +18,7 @@ new SDC environment and provision new instances there. Once an SDC headnode is
 setup, you may convert a SmartOS node to an SDC compute node by booting into
 "noinstall" mode, destroying the storage pool, and attaching the system to the
 SDC networks [as
-documented](https://docs.joyent.com/sdc7/overview-of-smartdatacenter-7).  This
+documented](https://docs.joyent.com/private-cloud/install/compute-node-setup).  This
 will destroy all existing instances and result in a new, empty SDC compute node
 ready for provisioning.  Migration of instances from SmartOS to SDC compute
 nodes and between SDC compute nodes may be possible using

--- a/docs/operator-guide/troubleshooting.md
+++ b/docs/operator-guide/troubleshooting.md
@@ -3,7 +3,7 @@
 This document tries to capture some of the less known SmartDataCenter
 troubleshooting steps and fixes. A more comprehensive troubleshooting guide
 can be found here:
-[Troubleshooting SDC7](https://docs.joyent.com/sdc7/troubleshooting-sdc7)
+[Troubleshooting](https://docs.joyent.com/private-cloud/troubleshooting)
 
 ## Upgrade
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -13,7 +13,7 @@ section in the glossary](./glossary.md#service) for details.
 
 | Name | Repo | Description |
 | ---- | ---- | ----------- |
-| [adminui](https://docs.joyent.com/sdc7/operations-portal-walkthrough) | [sdc-adminui](https://github.com/joyent/sdc-adminui) | SDC Operations Portal |
+| [adminui](https://docs.joyent.com/private-cloud/install/operations-setup) | [sdc-adminui](https://github.com/joyent/sdc-adminui) | SDC Operations Portal |
 | [amon](https://github.com/joyent/sdc-amon/blob/master/docs/index.md) | [sdc-amon](https://github.com/joyent/sdc-amon) | SDC monitoring and alarming |
 | amonredis | [sdc-amonredis](https://github.com/joyent/sdc-amonredis) | Internal infrastructure for the Amon service |
 | [binder](https://github.com/joyent/binder/blob/master/docs/index.md) | [binder](https://github.com/joyent/binder) | SDC/Manta DNS server over Apache Zookeeper |


### PR DESCRIPTION
Hi,

This goes along with https://github.com/joyent/documentation/pull/794 over in the docs repo - wanted to update the links in this repo to point to the correct location for FOSS users.

Not sure exactly the best way to go about this, so going to do a PR.

Jay

/cc: @pgale61 