### PR TITLE
Welcome Triton DataCenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,34 +9,34 @@
 -->
 
 
-# SmartDataCenter
+# Triton DataCenter
 
-SmartDataCenter (SDC) is an open-source cloud management platform, optimized
+Triton DataCenter (just "Triton" for short, formerly "SmartDataCenter" and "SDC") is an open-source cloud management platform, optimized
 to deliver next generation, container-based, service-oriented infrastructure
 across one or more data centers. With an emphasis on ease of installation
-and operation, SDC is proven at scale: it is the software that runs
+and operation, Triton is proven at scale: it is the software that runs
 the [Joyent public cloud](https://www.joyent.com/public-cloud)
 and powers
 [private clouds](https://www.joyent.com/products/private-cloud)
 at organizations of all size and industry.
 
-This repository provides documentation for the overall SDC project and
-pointers to the other repositories that make up a complete SDC deployment.
+This repository provides documentation for the overall Triton project and
+pointers to the other repositories that make up a complete Triton deployment.
 See the [repository list](./docs/developer-guide/repos.md).
 
-Report bugs and request features using [GitHub Issues](https://github.com/joyent/sdc/issues).
+Report bugs and request features using [GitHub Issues](https://github.com/joyent/triton/issues).
 For additional resources, you can visit the
 [Joyent Developer Center](https://www.joyent.com/developers).
 
 
 ## Overview
 
-A SmartDataCenter installation consists of two or more servers. All servers run
+A Triton DataCenter installation consists of two or more servers. All servers run
 [SmartOS](http://smartos.org). One server acts as the management server, the
-headnode, which houses the initial set of core services that drive SDC. The
+headnode, which houses the initial set of core services that drive Triton. The
 remainder are compute nodes (CNs) which run instances (virtual machines).
 
-SDC features:
+Triton features:
 
 - SmartOS zones provides high performance container virtualization. KVM support
   on top of zones means secure full Linux and Windows guest OS support.
@@ -46,7 +46,7 @@ SDC features:
   Node.js)
 - Automated USB key installation
 
-SDC consists of the following components:
+Triton consists of the following components:
 
 - A public API for provisioning and managing instances (virtual machines),
   networks, users, images, etc.
@@ -58,15 +58,15 @@ For more details, see:
 
 - The [Overview of Triton Elastic Container Infrastructure](https://docs.joyent.com/private-cloud)
   in the Joyent customer documentation.
-- [SmartDataCenter Architecture](./docs/developer-guide/architecture.md) for
+- [Triton DataCenter Architecture](./docs/developer-guide/architecture.md) for
   overall architecture.
-- [SmartDataCenter Reference](./docs/reference.md) for an
+- [Triton DataCenter Reference](./docs/reference.md) for an
   overview of each component.
 
 
 ## Community
 
-Community discussion about SmartDataCenter happens in two main places:
+Community discussion about Triton DataCenter happens in two main places:
 
 * The *sdc-discuss* mailing list. Once you [subscribe to the list](https://www.listbox.com/subscribe/?list_id=247449),
   you can send mail to the list address: sdc-discuss@lists.smartdatacenter.org.
@@ -82,9 +82,9 @@ Twitter for updates.
 
 ### Cloud on a Laptop (CoaL)
 
-An easy way to try SmartDataCenter is by downloading a Cloud on a Laptop
+An easy way to try Triton DataCenter is by downloading a Cloud on a Laptop
 (CoaL) build. This is a VMware virtual appliance providing a
-full SDC headnode for development and testing.
+full Triton headnode for development and testing.
 
 The minimum requirements, practically speaking, for a good CoaL experience
 is a **Mac with at least 16 GB RAM and an SSD**. Currently, almost all team
@@ -112,24 +112,24 @@ headnode.
 
     1. Launch VMware at least once after installing VMware.
 
-    2. Run SDC set up script for VMware:
+    2. Run Triton set up script for VMware:
 
          - Mac:
 
             ```bash
-            curl -s https://raw.githubusercontent.com/joyent/sdc/master/tools/coal-mac-vmware-setup | sudo bash
+            curl -s https://raw.githubusercontent.com/joyent/triton/master/tools/coal-mac-vmware-setup | sudo bash
             ```
 
          - Linux:
 
             ```bash
-            curl -s https://raw.githubusercontent.com/joyent/sdc/master/tools/coal-linux-vmware-setup | sudo bash
+            curl -s https://raw.githubusercontent.com/joyent/triton/master/tools/coal-linux-vmware-setup | sudo bash
             ```
 
          - Windows:
 
             ```
-            Download https://raw.githubusercontent.com/joyent/sdc/master/tools/coal-windows-vmware-setup.bat
+            Download https://raw.githubusercontent.com/joyent/triton/master/tools/coal-windows-vmware-setup.bat
             Run coal-windows-vmware-setup.bat
             ```
 
@@ -233,46 +233,46 @@ ssh root@10.99.99.7  # password 'rootpass'
 For just a taste run `svcs` to see running [SMF
 services](http://wiki.smartos.org/display/DOC/Using+the+Service+Management+Facility).
 Run `vmadm list` to see a list of current VMs (SmartOS
-[zones](http://wiki.smartos.org/display/DOC/Zones)). Each SDC service runs in
-its own zone. See [the Joyent customer documentation](https://docs.joyent.com/sdc7).
+[zones](http://wiki.smartos.org/display/DOC/Zones)). Each Triton service runs in
+its own zone. See [the Joyent customer documentation](https://docs.joyent.com/private-cloud).
 
 As mentioned previously, see [CoaL Setup](./docs/developer-guide/coal-setup.md)
 for a thorough walkthrough.
 
 
-### Installing SDC on a Physical Server
+### Installing Triton on a Physical Server
 
-A SmartDataCenter server runs SmartOS which is a live image. This means that
+A Triton DataCenter server runs SmartOS which is a live image. This means that
 it boots from a USB flash drive (key).
 a physical USB key, inserting the key and booting the server from that key.
-To install SDC, first obtain the latest release USB build.
+To install Triton, first obtain the latest release USB build.
 
 
 #### Hardware
 
-For SDC development only, the minimum server hardware is:
+For Triton development only, the minimum server hardware is:
 
 - 8 GB USB flash drive
 - Intel Processors with VT-x and EPT support (all Xeon since Nehalem)
 - 16 GB RAM
 - 6 GB available storage
 
-Hardware RAID is not recommended. SDC will lay down a ZFS ZPOOL across all
+Hardware RAID is not recommended. Triton will lay down a ZFS ZPOOL across all
 available disks on install. You'll want much more storage if you're working with
 images and instances.
 
-If setting up a SmartDataCenter pilot then you'll want to review
-the [Minimum Requirements](https://docs.joyent.com/sdc7/sdc7-minimium-requirements)
-and [Installation Prerequisites](https://docs.joyent.com/sdc7/sdc7-installation-prerequisites)
+If setting up a Triton DataCenter pilot then you'll want to review
+the [Minimum Requirements](https://docs.joyent.com/private-cloud/install/site-and-network-requirements)
+and [Installation Prerequisites](https://docs.joyent.com/private-cloud/install/deployment-planning)
 which include IPMI and at least 10 gigabit Ethernet. The supported hardware
 components for SmartOS are described in the [SmartOS Hardware Requirements](http://wiki.smartos.org/display/DOC/Hardware+Requirements).
-Joyent certified hardware for SmartDataCenter are all in
-the [Joyent Manufacturing Database](http://eng.joyent.com/manufacturing/).
+Joyent certified hardware for Triton DataCenter are all in
+the [Joyent Manufacturing Database](https://docs.joyent.com/private-cloud/hardware).
 
 
 #### Install
 
-To install SDC, first download the latest release image:
+To install Triton, first download the latest release image:
 
 ```bash
 curl -C - -O https://us-east.manta.joyent.com/Joyent_Dev/public/SmartDataCenter/usb-latest.tgz
@@ -281,17 +281,17 @@ curl -C - -O https://us-east.manta.joyent.com/Joyent_Dev/public/SmartDataCenter/
 Once you have downloaded the latest release image, you will need to
 [write it to a USB key](https://docs.joyent.com/private-cloud/install/installation-media)
 boot the headnode server using the USB key, and follow the install prompts. All steps necessary
-to plan, install, and configure SmartDataCenter (Triton) are available in the Joyent 
+to plan, install, and configure Triton DataCenter (Triton) are available in the Joyent 
 customer documenation [Installing Triton Elastic Container Infrastructure](https://docs.joyent.com/private-cloud/install).
 
 
 ## Building
 
-SDC is composed of several pre-built components:
+Triton is composed of several pre-built components:
 
 - A [SmartOS *platform* image](https://github.com/joyent/smartos-live). This is
-  a slightly customized build of vanilla SmartOS for SDC.
-- *Virtual machine images* for SDC services (e.g. imgapi, vmapi, adminui), which
+  a slightly customized build of vanilla SmartOS for Triton.
+- *Virtual machine images* for Triton services (e.g. imgapi, vmapi, adminui), which
   are provisioned as VMs at install time.
 - Agents bundled into a [single
   package](https://github.com/joyent/sdc-agents-installer)
@@ -308,16 +308,16 @@ and pulled from there. For example, Joyent's builds push to
 
 You can build your own CoaL and USB images on Mac or SmartOS (see the
 [sdc-headnode README](https://github.com/joyent/sdc-headnode#readme)). However,
-all other SDC components must be built using a running SDC
+all other Triton components must be built using a running Triton
 (e.g. on the [Joyent Cloud](https://www.joyent.com/products/compute-service)
 or in a local CoaL). See [the building document](./docs/developer-guide/building.md)
-for details on building each of the SDC components.
+for details on building each of the Triton components.
 
 
 ## Contributing
 
 To report bugs or request features, submit issues here on
-GitHub, [joyent/sdc/issues](https://github.com/joyent/sdc/issues).
+GitHub, [joyent/triton/issues](https://github.com/joyent/triton/issues).
 If you're contributing code, make pull requests to the appropriate
 repositories (see [the repo overview](./docs/developer-guide/repos.md)).
 If you're contributing something substantial, you should first contact
@@ -328,7 +328,7 @@ developers on the [sdc-discuss mailing list](mailto:sdc-discuss@lists.smartdatac
 For support of Joyent products and services, please contact [Joyent customer
 support](https://help.joyent.com/home) instead.
 
-SDC repositories follow the [Joyent Engineering Guidelines](https://github.com/joyent/eng/blob/master/docs/index.md).
+Triton repositories follow the [Joyent Engineering Guidelines](https://github.com/joyent/eng/blob/master/docs/index.md).
 Notably:
 
 - The #master branch should be first-customer-ship (FCS) quality at all times.
@@ -353,7 +353,7 @@ repo-specific lint rules -- look for "tools/jsl.web.conf" and
 
 ## Design Principles
 
-SmartDataCenter is very opinionated about how to architect a cloud. These
+Triton DataCenter is very opinionated about how to architect a cloud. These
 opinions are the result of many years of deploying and debugging
 the [Joyent public cloud](https://www.joyent.com/public-cloud).
 Design principles include the following:
@@ -363,12 +363,12 @@ Design principles include the following:
 - Communication between internal APIs should occur in its own control plane
   (network) that is separate from the customer networks. Avoid communicating
   over the open Internet if possible.
-- A provisioned VM should rely as little as possible on SDC services outside of
+- A provisioned VM should rely as little as possible on Triton services outside of
   the operating system for its normal operation.
 - Installation and operation should require as little human intervention as
   possible.
 
-The goals behind the design of SDC services include:
+The goals behind the design of Triton services include:
 
 - All parts of the stack should be observable.
 - The state of the running service should be simple to obtain.
@@ -385,18 +385,18 @@ The goals behind the design of SDC services include:
 
 ## Dependencies and Related Projects
 
-SmartDataCenter uses [SmartOS](http://smartos.org) as the host operating
+Triton DataCenter uses [SmartOS](http://smartos.org) as the host operating
 system. The SmartOS hypervisor provides both SmartOS zone (container) and
 KVM virtualization.
 
 Joyent's open-source [Manta project](https://github.com/joyent/manta)
 is an HTTP-based object store with built-in support to run arbitrary
 programs on data at rest (i.e., without copying data out of the object store).
-Manta runs on and integrates with SmartDataCenter.
+Manta runs on and integrates with Triton DataCenter.
 
 
 ## License
 
-SmartDataCenter is licensed under the
+Triton DataCenter is licensed under the
 [Mozilla Public License version 2.0](http://mozilla.org/MPL/2.0/).
 See the file LICENSE. SmartOS is [licensed separately](http://smartos.org/cddl/).


### PR DESCRIPTION
Triton DataCenter (just "Triton" for short) is the newest version of SDC. The progression was from SDC6.5 to SDC7, and then Triton. This new version ([unveiled on the Joyent cloud on March 24, 2015](https://www.joyent.com/blog/triton-docker-and-the-best-of-all-worlds)) represented such a significant leap forward in features and purpose that it demanded a new name. @bcantrill explained it best:

> With everything coming together, and with new hardware being stood up for the new service, there was one important task left: we needed to name this thing. (Somehow, “SmartOS + LX-branded zones + SmartDataCenter + sdc-portolan + sdc-docker” was a bit of a mouthful.) As we thought about names, I turned back to Solomon’s words a year ago: if this represented the best of two different worlds, what mythical creatures were combinations of different animals? While this search yielded many fantastic concoctions (a favorite being Manticore — and definitely don’t mess with Typhon!), there was one that stood out: Triton, son of Poseidon. As half-human and half-fish and a god of the deep, Triton represents the combination of two similar but different worlds — and as a bonus, the name rolls off the tongue and fits nicely with the marine metaphor that Docker has pioneered.

This PR renames references to SmartDataCenter and SDC in the README.md to reflect that name change. We will not rename previous interfaces or tools that incorporate the SDC name, but we'll use the Triton name going forward.

The changes introduced with the Triton release are already documented elsewhere, but it's worth repeating some of the highlights:

[Triton supports three types of compute](https://docs.joyent.com/public-cloud/instances):

- **Docker containers** running your choice of image from public and private registries. These were new with the introduction of Triton. Most exciting: these are pretty much just Docker images in a SmartOS Zone and inherit all the security, network, and performance advantages of running in a SmartOS Zone.
- **Infrastructure containers** running container-native Linux, including Certified Ubuntu, SmartOS, or pre-configured applications. These are implemented as SmartOS Zones, and with the introduction of Triton we officially supported running your choice of Linux via LX branded zones.
- **Hardware virtual machines** running legacy or special purpose operating systems for the broadest compatibility in our cloud. These are implemented with KVM inside a SmartOS Zone.

Triton introduced significant networking features:

Building on top of the [Crossbow networking](https://en.wikipedia.org/wiki/OpenSolaris_Network_Virtualization_and_Resource_Control) ([video](http://www.ustream.tv/recorded/1820786)) that SmartOS inherited from OpenSolaris, Joyent added user-defined VXLAN networking that allows every user to define their own networks and interconnect containers on them. This allows layer 2 network isolation between containers for maximum security and convenience.

Some of the changes in this PR presuppose changing the repo name from `sdc` to `triton`, but I must emphasize the exceptionality of that. We will not rename previous interfaces or tools that incorporate the SDC name, we'll simply use the Triton name going forward.